### PR TITLE
add config for klaro to be installable through npm registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 package-lock.json
 .tmp
 node_modules
+dist/klaro.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+*
+!dist/klaro.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "klaro",
-  "version": "1.0.0",
+  "version": "0.2.1",
   "description": "A simple consent manager.",
   "repository": {
     "type": "git",
@@ -12,9 +12,11 @@
     "gdpr",
     "compliance"
   ],
+  "main": "dist/klaro.js",
   "scripts": {
     "make-dev": "APP_ENV=dev webpack-dev-server --config webpack.config.js --history-api-fallback",
-    "make": "APP_VERSION=`git tag --points-at HEAD` APP_COMMIT=`git rev-parse HEAD` webpack --config webpack-production.config.js"
+    "make": "APP_VERSION=`git tag --points-at HEAD` APP_COMMIT=`git rev-parse HEAD` webpack --config webpack-production.config.js",
+    "prepublishOnly": "npm run make"
   },
   "author": "DP-Kit",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Hi,

Thanks a lot for this project and for open sourcing it. We searched for similar libraries recently to use in my company and yours seems really great.

We are working on integrating this on our workflow, and certainly improving the accessibility. My work here starts with being able to install klaro via npm for easier installs.

This code should help you if you want to publish klaro on the public npm registry. What do you think?

related issue: #23 