### PR TITLE
Made Klaro work in IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-loader": "^7.1.4",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-minify": "^0.4.3",
@@ -48,5 +49,9 @@
     "webpack-dev-server": "^2.4.5",
     "webpack-hot-middleware": "^2.20.0",
     "yaml-loader": "^0.5.0"
+  },
+  "dependencies": {
+    "babel-runtime": "^6.26.0",
+    "current-executing-script": "^0.1.3"
   }
 }

--- a/src/consent-manager.js
+++ b/src/consent-manager.js
@@ -174,7 +174,7 @@ export default class ConsentManager {
                 newElement.innerText = element.innerText
                 newElement.text = element.text
                 newElement.class = element.class
-                newElement.style = element.style
+                newElement.style.cssText = element.style
                 newElement.id = element.id
                 newElement.name = element.name
                 newElement.defer = element.defer

--- a/src/klaro.js
+++ b/src/klaro.js
@@ -7,12 +7,14 @@ import {render} from 'react-dom'
 import translations from 'translations'
 import {convertToMap, update} from 'utils/maps'
 import {t, language} from 'utils/i18n'
+import currentExecutingScript from 'current-executing-script';
 
+const script = document.currentScript || currentExecutingScript();
 const originalOnLoad = window.onload
 const convertedTranslations = convertToMap(translations)
-const configName = document.currentScript.dataset.config || "klaroConfig"
-const noAutoLoad = document.currentScript.dataset.noAutoLoad == "true"
-const stylePrefix = document.currentScript.dataset.stylePrefix || "klaro"
+const configName = script.dataset.config || "klaroConfig"
+const noAutoLoad = script.dataset.noAutoLoad == "true"
+const stylePrefix = script.dataset.stylePrefix || "klaro"
 const config = window[configName]
 const managers = {}
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,9 +43,10 @@ var config = {
       },
       {
         test: /\.jsx?/,
-        include: [path.resolve('node_modules'), SRC_DIR],
+        include: [SRC_DIR],
         loader: 'babel-loader',
         query: {
+          plugins: ["transform-runtime"],
           presets: [["env", { "modules": false }], 'react', 'stage-2'],
         }
       }


### PR DESCRIPTION
I've made some small changes in Klaro to make it work in IE11.
For this I've introduced some new dependencies:

- [Babel-plugin-transform-runtime](https://babeljs.io/docs/en/6.26.3/babel-plugin-transform-runtime): to polyfill ES6 features only where it is needed (this works together witht the babel-runtime dependency)
- [currentExecutingScript](https://github.com/JamesMGreene/currentExecutingScript): to stand in for document.currentExecutingScript in IE11 which doesn't have this function

I've also removed node_modules from the webpack babel-loader config because node modules are alreade ES5 and don't need to be transpiled (the code also didn't compile with this included + babel-plugin-transform-runtime) and changed the setter of style to style.cssText for better compatibility.
