### PR TITLE
Fix example config: Don't overwrite English with Turkish

### DIFF
--- a/dist/configs/i18n.js
+++ b/dist/configs/i18n.js
@@ -60,7 +60,7 @@ var klaroI18nConfig = {
                 description: 'Real-time user analytics',
             },
         },
-        en: {
+        tr: {
             consentModal: {
                 title: 'Bu, izin penceresinin başlığı',
                 description: 'Bu, izin penceresi için açıklama.',


### PR DESCRIPTION
The property name for the Turkish translation is incorrectly set to `en`, overwriting the additional English strings.