### PR TITLE
Add Catalan language

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This GIF shows how Klaro deletes Cookies as the user disables apps. A full-lengt
 * **Flexible and customizable**: Manage consent for all possible types of
   third-party apps and easily customize the tool according to your needs.
 * **Multilingual**: Full internationalization support, with languages included out of the box. New translations can be added in just a few lines of code. Contributions welcome! Current languages:
+    - [x] Catalan
     - [x] Dutch
     - [x] English
     - [x] Finnish

--- a/src/translations/ca.yml
+++ b/src/translations/ca.yml
@@ -1,0 +1,30 @@
+consentModal:
+  title: Informació que recopilem
+  description: >
+    Aquí podeu veure i personalitzar la informació que recopilem sobre vós.
+  privacyPolicy:
+    name: política de privadesa
+    text: >
+      Per a més informació, consulteu la nostra {privacyPolicy}.
+consentNotice:
+  changeDescription: Hi ha hagut canvis des de la vostra darrera visita. Actualitzeu el vostre consentiment.
+  description: >
+    Recopilem i processem la vostra informació personal amb les següents finalitats: {purposes}.
+  learnMore: Saber-ne més
+ok: Accepta
+save: Desa
+decline: Rebutja
+close: Tanca
+app:
+  disableAll:
+    title: Habilita/deshabilita totes les aplicacions
+    description: Useu aquest botó per a habilitar o deshabilitar totes les aplicacions.
+  optOut:
+    title: (opt-out)
+    description: Aquesta aplicació es carrega per defecte, però podeu desactivar-la
+  required:
+    title: (necessària)
+    description: Aquesta aplicació es necessita sempre
+  purposes: Finalitats
+  purpose: Finalitat
+poweredBy: Funciona amb Klaro!

--- a/src/translations/index.js
+++ b/src/translations/index.js
@@ -1,6 +1,7 @@
 // To create a new translation, add a YAML file with the required entries and
 // link it here using the appropriate language code.
 
+import ca from './ca.yml'
 import de from './de.yml'
 import el from './el.yml'
 import en from './en.yml'
@@ -17,6 +18,7 @@ import tr from './tr.yml'
 import pl from './pl.yml'
 
 export default {
+  ca,
   de,
   el,
   en,


### PR DESCRIPTION
As stated in issue #1, Catalan language translation is provided on this PR.

- Created Catalan translation strings.
- Updated `src/translations/index.js`.
- Updated `README.md`.