### PR TITLE
Add cross-env support with cross-env-shell

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2303,6 +2303,31 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-env": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "is-windows": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
@@ -3847,7 +3872,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -4760,8 +4784,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -4786,7 +4809,6 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -5552,6 +5574,12 @@
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
     "node-forge": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
@@ -5676,7 +5704,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
-      "optional": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   ],
   "main": "dist/klaro.js",
   "scripts": {
-    "make-dev": "APP_ENV=dev APP_DEV_MODE=server webpack-dev-server --config webpack.config.js --history-api-fallback",
-    "make-watch": "APP_ENV=dev APP_DEV_MODE=watch webpack --watch --config webpack.config.js",
-    "make": "APP_ENV=production APP_VERSION=`git tag --points-at HEAD` APP_COMMIT=`git rev-parse HEAD` webpack --config webpack.config.js"
+    "make-dev": "cross-env APP_ENV=dev cross-env APP_DEV_MODE=server webpack-dev-server --config webpack.config.js --history-api-fallback",
+    "make-watch": "cross-env APP_ENV=dev cross-env APP_DEV_MODE=watch webpack --watch --config webpack.config.js",
+    "make": "cross-env APP_ENV=production cross-env APP_VERSION=`git tag --points-at HEAD` cross-env APP_COMMIT=`git rev-parse HEAD` webpack --config webpack.config.js"
   },
   "author": "kj7s GbR",
   "license": "BSD-3-Clause",
@@ -33,6 +33,7 @@
     "babel-preset-minify": "^0.4.3",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
+    "cross-env": "^5.2.0",
     "css-loader": "^0.28.4",
     "file-loader": "^0.11.1",
     "json-loader": "^0.5.7",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   ],
   "main": "dist/klaro.js",
   "scripts": {
-    "make-dev": "cross-env APP_ENV=dev cross-env APP_DEV_MODE=server webpack-dev-server --config webpack.config.js --history-api-fallback",
-    "make-watch": "cross-env APP_ENV=dev cross-env APP_DEV_MODE=watch webpack --watch --config webpack.config.js",
-    "make": "cross-env APP_ENV=production cross-env APP_VERSION=`git tag --points-at HEAD` cross-env APP_COMMIT=`git rev-parse HEAD` webpack --config webpack.config.js"
+    "make-dev": "cross-env-shell \"APP_ENV=dev APP_DEV_MODE=server webpack-dev-server --config webpack.config.js --history-api-fallback\"",
+    "make-watch": "cross-env-shell \"APP_ENV=dev APP_DEV_MODE=watch webpack --watch --config webpack.config.js\"",
+    "make": "cross-env-shell \"APP_ENV=production APP_VERSION=`git tag --points-at HEAD` APP_COMMIT=`git rev-parse HEAD` webpack --config webpack.config.js\""
   },
   "author": "kj7s GbR",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
A continuation of #85 that uses cross-env-shell instead of stacked cross-env calls.

https://github.com/KIProtect/klaro/pull/85#issuecomment-520756602