### PR TITLE
Add issue templates for bugs reports, feature requests and questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/BugReport.md
+++ b/.github/ISSUE_TEMPLATE/BugReport.md
@@ -1,0 +1,25 @@
+---
+name: "\U0001F41B Bug report"
+about: Something isn't working as expected
+---
+
+**Steps to reproduce**
+
+<!--
+A step by step description of how to get to the error state.
+Can you upload your config as a Gist? https://gist.github.com/
+Can you create a minimal repository to reproduce the error?
+-->
+
+**Current behavior**
+
+<!--
+A clear and concise description of what the bug is.
+Please include any JavaScript errors.
+-->
+
+**Expected behavior**
+
+<!--
+What did you expect to happen?
+-->

--- a/.github/ISSUE_TEMPLATE/FeatureRequest.md
+++ b/.github/ISSUE_TEMPLATE/FeatureRequest.md
@@ -1,0 +1,22 @@
+---
+name: "\U0001F680 Feature request"
+about: I have a suggestion (and might want to implement myself)
+---
+
+<!-- Consider opening a pull request instead: it's a more productive way to discuss new features -->
+
+**The problem**
+
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Proposed solution**
+
+<!-- A clear and concise description of what you want to happen. Add any considered drawbacks. -->
+
+**Alternative solutions**
+
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Additional context**
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -1,0 +1,11 @@
+---
+name: "\U0001F914 Support question"
+about: I have a question or don’t know how to do something
+---
+
+If you have a support question, feel free to ask it here.
+
+Before submitting a new question, please make sure you:
+
+- Read [the introduction](https://klaro.kiprotect.com).
+- Searched opened and closed [GitHub issues](https://github.com/KIProtect/klaro/issues?utf8=%E2%9C%93&q=is%3Aissue).


### PR DESCRIPTION
Processing tickets takes up more time when the statements and questions aren't concise.

To help people get their issues resolved faster, I want to give them some help with these issue templates.

Have a look at [MapsCII's template picker](https://github.com/rastapasta/mapscii/issues/new/choose) to see how they work.