### PR TITLE
Don't pollute String.prototype with format()

### DIFF
--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -1,19 +1,16 @@
-String.prototype.format = function () {
-    "use strict";
-    var str = this.toString();
-
-    var t = typeof arguments[0];
+const format = (str, ...rest) => {
+    var t = typeof rest[0];
     var args
-    if (arguments.length === 0)
+    if (rest.length === 0)
         args = {}
     else
         args = ("string" === t || "number" === t) ?
-                Array.prototype.slice.call(arguments)
-                : arguments[0];
+                Array.prototype.slice.call(rest)
+                : rest[0];
 
     var splits = []
 
-    var s = str
+    var s = str.toString()
     while(s.length > 0){
         var m = s.match(/\{(?!\{)([\w\d]+)\}(?!\})/)
         if (m !== null){
@@ -63,16 +60,15 @@ function hget(d, key, defaultValue){
     return cv
 }
 
-export function t(trans, lang, key){
+export function t(trans, lang, key, ...params){
     var kl = key
     if (!Array.isArray(kl))
         kl = [kl]
     const value = hget(trans, [lang, ...kl])
     if (value === undefined){
-        return '[missing translation: {lang}/{key}]'.format({key: kl.join("/"), lang: lang}).join("")
+        return `[missing translation: ${lang}/${kl.join("/")}]`;
     }
-    const params = Array.prototype.slice.call(arguments, 3)
     if (params.length > 0)
-        return value.format(...params)
+        return format(value, ...params)
     return value
 }


### PR DESCRIPTION
Fixes #110 

The prototypes of globals and default types should not be changed. It may cause side-effects in or from other scripts.