### PR TITLE
Update maintainer & authors information from DPKit to KIProtect

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,9 @@
 BSD 3-Clause License
 
 Copyright (c) 2018, DPKit
+Copyright (c) 2019, KIProtect GmbH
+Copyright (c) various authors obtainable by running `git shortlog -nse` or
+visiting https://github.com/KIProtect/klaro/graphs/contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/dist/config.js
+++ b/dist/config.js
@@ -40,10 +40,10 @@ var klaroConfig = {
     // You can overwrite existing translations and add translations for your
     // app descriptions and purposes. See `src/translations.yml` for a full
     // list of translations that can be overwritten:
-    // https://github.com/DPKit/klaro/blob/master/src/translations.yml
+    // https://github.com/KIProtect/klaro/blob/master/src/translations.yml
 
     // Example config that shows how to overwrite translations:
-    // https://github.com/DPKit/klaro/blob/master/src/configs/i18n.js
+    // https://github.com/KIProtect/klaro/blob/master/src/configs/i18n.js
     translations: {
         // If you erase the "consentModal" translations, Klaro will use the
         // defaults as defined in translations.yml

--- a/dist/configs/i18n.js
+++ b/dist/configs/i18n.js
@@ -5,12 +5,12 @@ var klaroI18nConfig = {
     noNotice: true,
     privacyPolicy: '/#privacy',
     poweredBy:
-        'https://github.com/DPKit/klaro/blob/master/dist/configs/i18n.js',
+        'https://github.com/KIProtect/klaro/blob/master/dist/configs/i18n.js',
     default: true,
     translations: {
         // these values will overwrite the defaults. For a full list, have a look
         // at the `translations.yml` file in the `src` directory of this repo:
-        // https://github.com/DPKit/klaro/blob/master/src/translations.yml
+        // https://github.com/KIProtect/klaro/blob/master/src/translations.yml
         de: {
             consentModal: {
                 title: 'Dies ist der Titel des Zustimmungs-Dialogs',

--- a/dist/index.html
+++ b/dist/index.html
@@ -492,9 +492,7 @@
                 <h1 class="title"><a name="privacy">Privacy Policy</a></h1>
                 <div class="content">
                     <p>
-                        This website is a project by <a href="https://dpkit.com/impressum.html">DPKit</a>
-                        &amp; <a href="https://kiprotect.com/imprint.html">KIProtect</a> (KIProtect
-                        is the responsible data controller).
+                        This website is a project by <a href="https://kiprotect.com/company/imprint">KIProtect</a>.
                         We use third-party applications and cookies on this site
                         for analytics, demonstration purposes and security.
                         You can review your consents

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "make-watch": "cross-env APP_ENV=dev cross-env APP_DEV_MODE=watch webpack --watch --config webpack.config.js",
     "make": "cross-env APP_ENV=production cross-env APP_VERSION=\"git tag --points-at HEAD\" cross-env APP_COMMIT=\"git rev-parse HEAD\" webpack --config webpack.config.js"
   },
-  "author": "kj7s GbR",
+  "author": "KIProtect GmbH",
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/KIProtect/klaro/issues"


### PR DESCRIPTION
The legal entity KIProtect GmbH has replaced the former entity DPKit as a maintainer of "Klaro!".
These changes update links and information about who maintains the software.

Furthermore, the Pull Request adds information about how to receive the list of all copyright holders of this BSD-3-Clause-licensed open source work.