### PR TITLE
Documentation: Correct location of the translations

### DIFF
--- a/dist/config.js
+++ b/dist/config.js
@@ -38,15 +38,15 @@ var klaroConfig = {
     //lang: 'en',
 
     // You can overwrite existing translations and add translations for your
-    // app descriptions and purposes. See `src/translations.yml` for a full
+    // app descriptions and purposes. See `src/translations/` for a full
     // list of translations that can be overwritten:
-    // https://github.com/KIProtect/klaro/blob/master/src/translations.yml
+    // https://github.com/KIProtect/klaro/tree/master/src/translations
 
     // Example config that shows how to overwrite translations:
     // https://github.com/KIProtect/klaro/blob/master/src/configs/i18n.js
     translations: {
         // If you erase the "consentModal" translations, Klaro will use the
-        // defaults as defined in translations.yml
+        // bundled translations.
         de: {
             consentModal: {
                 description:

--- a/dist/configs/i18n.js
+++ b/dist/configs/i18n.js
@@ -9,8 +9,8 @@ var klaroI18nConfig = {
     default: true,
     translations: {
         // these values will overwrite the defaults. For a full list, have a look
-        // at the `translations.yml` file in the `src` directory of this repo:
-        // https://github.com/KIProtect/klaro/blob/master/src/translations.yml
+        // at the `src/translations` directory of this repo:
+        // https://github.com/KIProtect/klaro/tree/master/src/translations
         de: {
             consentModal: {
                 title: 'Dies ist der Titel des Zustimmungs-Dialogs',


### PR DESCRIPTION
Resolves #119.

The translations have been moved to individual files in the `/src/translations` folder:

https://github.com/KIProtect/klaro/tree/master/src/translations