### PR TITLE
Fix #135 by ensuring the z-index of the close button

### DIFF
--- a/src/scss/klaro.scss
+++ b/src/scss/klaro.scss
@@ -121,7 +121,7 @@ $green3: #01440C;
             overflow: auto;
             background: $bg-dark;
             color: $font-color-dark;
-    
+
             .hide   {
                 border: none;
                 background: none;
@@ -131,6 +131,10 @@ $green3: #01440C;
                 position: absolute;
                 top: 20px;
                 right: 20px;
+                // Avoid getting overlapped by the heading, if external CSS sets:
+                // h1 { position: relative }
+                // See: https://github.com/KIProtect/klaro/issues/135
+                z-index: 1;
             }
 
             .cm-footer {
@@ -253,7 +257,7 @@ $green3: #01440C;
             p.cn-changes {
                 text-decoration: underline;
             }
-    
+
             .cn-learn-more {
                 display: inline-block;
 


### PR DESCRIPTION
Fixes #153 by adding `z-index: 1` to the X (close) button inside the modal.

If external CSS applies `position: relative` on `h1`s, the heading will make the button inaccessible by overlapping it.

![klaro-title](https://user-images.githubusercontent.com/10872136/70240934-6c5b8500-176e-11ea-8e59-14b3a7370d52.png)
