### PR TITLE
Fix klaro cookie not being deleted if set on other page.

### DIFF
--- a/src/consent-manager.js
+++ b/src/consent-manager.js
@@ -79,7 +79,7 @@ export default class ConsentManager {
         this.consents = this.defaultConsents
         this.confirmed = false
         this.applyConsents()
-        deleteCookie(this.cookieName)
+        deleteCookie(this.cookieName, '/')
         this.notify('consents', this.consents)
     }
 


### PR DESCRIPTION
This PR fixes the klaro-cookie not being deleted when `klaro.getManager().resetConsent()` was **not** called from the top-level page (e.g. `/`). The path `/` needs to be defined explicitly to delete the cookie, just like it is defined when setting the cookie in https://github.com/KIProtect/klaro/blob/29842b836b1b6531baff19be025c36724d6e7a33/src/utils/cookies.js#L37

You can reproduce the issue on my testing page at https://matjaeck.github.io/klaro_testing/unfixed/, which uses the klaro distribution from https://unpkg.com/klaro@0.2.12/dist/klaro.js. The fix can be inspected at https://matjaeck.github.io/klaro_testing/fixed/, which includes the commit below.

To reproduce, activate the "Facebook Content" app (it will query an image from fb), then try to reset consent.