### PR TITLE
Remove a non-operational call to deleteCookie().

### DIFF
--- a/src/consent-manager.js
+++ b/src/consent-manager.js
@@ -123,8 +123,6 @@ export default class ConsentManager {
     }
 
     saveConsents(){
-        if (this.consents === null)
-            deleteCookie(this.cookieName)
         const v = JSON.stringify(this.consents)
         setCookie(this.cookieName, v, this.config.cookieExpiresAfterDays || 120)
         this.confirmed = true


### PR DESCRIPTION
This removes a non-operational call to `deleteCookie()` from the `saveConsents()` method. The intention of this code was probably to delete the cookie when no consent was given to any app (correct me if I'm wrong), however it does not work like that.

`this.consents === null` implies that `get defaultConsents()` could return null, which is not the case because even if there aren't any apps configured, `{} !== null`, see 
https://github.com/KIProtect/klaro/blob/29842b836b1b6531baff19be025c36724d6e7a33/src/consent-manager.js#L54

We also do not want to delete the cookie when no consent was given but save the user's choice for his next visits.

I might be missing something but I can't see how `this.consents === null` could ever be true. We also do not perform any null-checks anywhere else.