### PR TITLE
Don't force confirmation to close modal when visiting privacy policy page

### DIFF
--- a/dist/config.js
+++ b/dist/config.js
@@ -20,15 +20,17 @@ var klaroConfig = {
     // You can customize the name of the cookie that Klaro will use to
     // store user consent. If undefined, Klaro will use 'klaro'.
 
-    // Put a link to your privacy policy here (relative or absolute).
+    // Put a link to your privacy policy here. Absolute paths need to include the protocol
+    // and relative paths have to start and end with a forward slash.
+    // (e.g. http://localhost:8080/privacy/ vs. /privacy/).
     privacyPolicy: '/#privacy',
 
     // Defines the default state for applications (true=enabled by default).
     default: true,
 
     // If "mustConsent" is set to true, Klaro will directly display the consent
-    // manager modal and not allow the user to close it before having actively
-    // consented or declines the use of third-party apps.
+    // manager modal and not allow the user to close it without confirmation.
+    // However, the modal will close when visitng the privacyPolicy page.
     mustConsent: false,
 
     // You can define the UI language directly here. If undefined, Klaro will

--- a/dist/config.js
+++ b/dist/config.js
@@ -23,7 +23,7 @@ var klaroConfig = {
     // Put a link to your privacy policy here. Absolute paths need to include the protocol
     // and relative paths have to start and end with a forward slash.
     // (e.g. http://localhost:8080/privacy/ vs. /privacy/).
-    privacyPolicy: '/#privacy',
+    privacyPolicy: '/privacy/',
 
     // Defines the default state for applications (true=enabled by default).
     default: true,
@@ -31,7 +31,7 @@ var klaroConfig = {
     // If "mustConsent" is set to true, Klaro will directly display the consent
     // manager modal and not allow the user to close it without confirmation.
     // However, the modal will close when visitng the privacyPolicy page.
-    mustConsent: false,
+    mustConsent: true,
 
     // You can define the UI language directly here. If undefined, Klaro will
     // use the value given in the global "lang" variable. If that does

--- a/dist/privacy/index.html
+++ b/dist/privacy/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <script defer type="application/javascript" src="../config.js"></script>
+    <script defer type="application/javascript" src="../klaro.js" data-config="klaroConfig" data-style-prefix="klaro"></script>
+    <title>Policy</title>
+</head>
+<body>
+    <p>Policy</p>
+    <p>
+        <a href="# class="button is-success" onClick="return klaro.show();">Show manager</a>
+        <a href="# class="button is-warning" onClick="klaro.getManager().resetConsent();location.reload()">Reset consent</a>
+    </p>
+</body>
+</html>

--- a/src/components/consent-modal.js
+++ b/src/components/consent-modal.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import {Close} from './icons'
 import Apps from './apps'
+import {locationIsPrivacyPage} from 'utils/config'
 
 export default class ConsentModal extends React.Component {
 
@@ -8,7 +9,7 @@ export default class ConsentModal extends React.Component {
         const {hide, saveAndHide, config, manager, t} = this.props
 
         let closeLink
-        if (!config.mustConsent) {
+        if (!config.mustConsent || locationIsPrivacyPage(config)) {
             closeLink = <button
                 title={t(['close'])}
                 className="hide"

--- a/src/components/consent-notice.js
+++ b/src/components/consent-notice.js
@@ -60,12 +60,12 @@ export default class ConsentNotice extends React.Component {
             <div className="cn-body">
                 <p>
                     {t(['consentNotice', 'description'], {purposes: <strong>{purposesText}</strong>})}
-                    <a href="#" onClick={this.showModal}>{t(['consentNotice', 'learnMore'])}...</a>
                 </p>
                 {changesText}
                 <p className="cn-ok">
-                    <button className="cm-btn cm-btn-sm cm-btn-success" type="button" onClick={this.saveAndHide}>{t(['ok'])}</button>
-                    <button className="cm-btn cm-btn-sm cm-btn-danger cn-decline" type="button" onClick={this.declineAndHide}>{t(['decline'])}</button>
+                    <button className="cm-btn cm-btn-success" type="button" onClick={this.saveAndHide}>{t(['ok'])}</button>
+                    <button className="cm-btn" type="button" onClick={this.declineAndHide}>{t(['decline'])}</button>
+                    <button className="cm-btn cm-btn-info" type="button" onClick={this.showModal}>{t(['consentNotice', 'learnMore'])}</button>
                 </p>
             </div>
         </div>

--- a/src/components/consent-notice.js
+++ b/src/components/consent-notice.js
@@ -17,21 +17,15 @@ export default class ConsentNotice extends React.Component {
             this.setState({modal : undefined})
     }
 
-    showModal = (e) => {
-        if (e !== undefined)
-            e.preventDefault()
+    showModal = () => {
         this.setState({modal: true})
     }
 
-    hide = (e) => {
-        if (e !== undefined)
-            e.preventDefault()
+    hide = () => {
         this.setState({modal: false})
     }
 
-    saveAndHide = (e) => {
-        if (e !== undefined)
-            e.preventDefault()
+    saveAndHide = () => {
         this.props.manager.saveAndApplyConsents()
         this.setState({modal: false})
     }

--- a/src/components/consent-notice.js
+++ b/src/components/consent-notice.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ConsentModal from './consent-modal'
-import {getPurposes} from 'utils/config'
+import {getPurposes, locationIsPrivacyPage} from 'utils/config'
 
 export default class ConsentNotice extends React.Component {
 
@@ -51,10 +51,12 @@ export default class ConsentNotice extends React.Component {
         if (manager.confirmed && !show)
             return <div />
 
-        const noticeIsVisible =
-            !config.mustConsent && !manager.confirmed && !config.noNotice
+        const ppAt = locationIsPrivacyPage(config)
 
-        if (modal || (show && modal === undefined) || (config.mustConsent && !manager.confirmed))
+        const noticeIsVisible =
+            (!config.mustConsent || ppAt) && !manager.confirmed && !config.noNotice
+
+        if (modal || (show && modal === undefined) || (config.mustConsent && (!manager.confirmed && !ppAt)))
             return <ConsentModal t={t} config={config} hide={this.hide} declineAndHide={this.declineAndHide} saveAndHide={this.saveAndHide} manager={manager} />
         return <div className={`cookie-notice ${!noticeIsVisible ? 'cookie-notice-hidden' : ''}`}>
             <div className="cn-body">

--- a/src/scss/klaro.scss
+++ b/src/scss/klaro.scss
@@ -47,10 +47,10 @@ $green3: #01440C;
         }
 
         .cm-btn {
-            box-shadow: $box-shadow;
+            background: #555;
             color: $font-color-dark;
             border-radius: 6px;
-            padding: 0.5em;
+            padding: 6px 10px;
             margin-right: 0.5em;
             border: 0;
 
@@ -66,10 +66,6 @@ $green3: #01440C;
 
             &.cm-btn-success {
                 background: $green1;
-            }
-
-            &.cm-btn-danger {
-                background: $blue3;
             }
 
             &.cm-btn-info {
@@ -266,9 +262,6 @@ $green3: #01440C;
             p.cn-ok {
                 padding-top: 0.5em;
                 margin: 0;
-            }
-
-            a.cn-decline {
             }
         }
 

--- a/src/translations/en.yml
+++ b/src/translations/en.yml
@@ -11,7 +11,7 @@ consentNotice:
   description: >
     We collect and process your personal information for the following purposes: {purposes}.
   learnMore: Learn more
-ok: OK
+ok: Accept
 save: Save
 decline: Decline
 close: Close

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -7,3 +7,20 @@ export function getPurposes(config){
     }
     return Array.from(purposes)
 }
+
+export function locationIsPrivacyPage(config){
+    const getPolicyUrl = () => {
+        try{
+            // Absolute path
+            return new URL(config.privacyPolicy).pathname
+        }catch(e){
+            // Relative path
+            return new URL(config.privacyPolicy, document.baseURI).pathname
+        }
+    }
+
+    if (getPolicyUrl() === window.location.pathname)
+        return true
+
+    return false
+}


### PR DESCRIPTION
This PR changes some of the logic of `mustConsent` so that the modal is not opened by default and can be closed when visiting the defined privacy policy page. The motivation behind the change is that we need to allow users to inform themselves before making a decision in order to obtain legally valid consent. I'm open for suggestions if anybody can come up with a better implementation.

Testcase commit needs to be dropped before merging.

Depends on #153, so reviewing by commit is recommended.
Fixes #155.