### PR TITLE
Escape/unescape cookie when saving/loading consents

### DIFF
--- a/src/consent-manager.js
+++ b/src/consent-manager.js
@@ -110,7 +110,7 @@ export default class ConsentManager {
     loadConsents(){
         const consentCookie = getCookie(this.cookieName)
         if (consentCookie !== null){
-            this.consents = JSON.parse(consentCookie.value)
+            this.consents = JSON.parse(decodeURIComponent(consentCookie.value))
             this._checkConsents()
             this.notify('consents', this.consents)
         }
@@ -123,7 +123,7 @@ export default class ConsentManager {
     }
 
     saveConsents(){
-        const v = JSON.stringify(this.consents)
+        const v = encodeURIComponent(JSON.stringify(this.consents))
         setCookie(this.cookieName, v, this.config.cookieExpiresAfterDays || 120)
         this.confirmed = true
         this.changed = false


### PR DESCRIPTION
Rationale for this change is this section from RFC2109
(https://tools.ietf.org/html/rfc2109):

```
Note: For backward compatibility, the separator in the Cookie header
is semi-colon (;) everywhere.  A server should also accept comma (,)
as the separator between cookie-values for future compatibility.
```

Several server-side implementations of Cookie Jars (e.g. rack, the
modular Ruby webserver interface, that is used in a.o. ruby-on-rails)
therefore split the `Cookie` header on `;` and `,`. The unescaped JSON
of the consents contains `,` which causes issues server-side.

This change is able to read cookies written by an older version as
`unescape` will only replace escaped sequences.