### PR TITLE
Implement possibility of using Multilanguage link for privacyPolicy

### DIFF
--- a/dist/configs/i18n.js
+++ b/dist/configs/i18n.js
@@ -3,7 +3,10 @@ var klaroI18nConfig = {
     elementID: 'i18n',
     lang: 'en',
     noNotice: true,
-    privacyPolicy: '/#privacy',
+    privacyPolicy: {
+        default: '/#privacy',
+        de: '/#datenschutz',
+    },
     poweredBy:
         'https://github.com/KIProtect/klaro/blob/master/dist/configs/i18n.js',
     default: true,

--- a/dist/configs/i18n.js
+++ b/dist/configs/i18n.js
@@ -16,11 +16,11 @@ var klaroI18nConfig = {
                 title: 'Dies ist der Titel des Zustimmungs-Dialogs',
                 description:
                     'Dies ist die Beschreibung des Zustimmungs-Dialogs.',
-            },
-            privacyPolicy: {
-                text:
-                    'Dies ist der Text mit einem Link zu Ihrer {privacyPolicy}.',
-                name: 'Datenschutzerklärung (Name)',
+                privacyPolicy: {
+                    text:
+                        'Dies ist der Text mit einem Link zu Ihrer {privacyPolicy}.',
+                    name: 'Datenschutzerklärung (Name)',
+                },
             },
             poweredBy: 'Konfiguration ansehen',
             ok: "Los geht's!",
@@ -41,10 +41,10 @@ var klaroI18nConfig = {
             consentModal: {
                 title: 'This is the title of the consent modal',
                 description: 'This is the description of the consent modal.',
-            },
-            privacyPolicy: {
-                text: 'This is the text with a link to your {privacyPolicy}.',
-                name: 'privacy policy (the name)',
+                privacyPolicy: {
+                    text: 'This is the text with a link to your {privacyPolicy}.',
+                    name: 'privacy policy (the name)',
+                },
             },
             poweredBy: 'view config',
             ok: 'Wohoo!',
@@ -64,10 +64,10 @@ var klaroI18nConfig = {
             consentModal: {
                 title: 'Bu, izin penceresinin başlığı',
                 description: 'Bu, izin penceresi için açıklama.',
-            },
-            privacyPolicy: {
-                text: 'Bu {privacyPolicy} için bir bağlantı.',
-                name: 'Gizlilik Politikası (isim)',
+                privacyPolicy: {
+                    text: 'Bu {privacyPolicy} için bir bağlantı.',
+                    name: 'Gizlilik Politikası (isim)',
+                },
             },
             poweredBy: 'Yapılandırmayı Görüntüle',
             ok: 'Wohoo!',

--- a/src/components/consent-modal.js
+++ b/src/components/consent-modal.js
@@ -1,11 +1,13 @@
 import React from 'react'
 import {Close} from './icons'
 import Apps from './apps'
+import {language} from 'utils/i18n'
 
 export default class ConsentModal extends React.Component {
 
     render(){
         const {hide, saveAndHide, config, manager, t} = this.props
+        const lang = config.lang || language()
 
         let closeLink
         if (!config.mustConsent) {
@@ -19,7 +21,11 @@ export default class ConsentModal extends React.Component {
             </button>
         }
 
-        const ppLink = <a onClick={hide} href={config.privacyPolicy}>{t(['consentModal','privacyPolicy','name'])}</a>
+        const PPHref = (config.privacyPolicy && config.privacyPolicy[lang]) || 
+            config.privacyPolicy.default ||
+            config.privacyPolicy
+
+        const ppLink = <a onClick={hide} href={PPHref}>{t(['consentModal','privacyPolicy','name'])}</a>
         return <div className="cookie-modal">
             <div className="cm-bg" onClick={hide}/>
             <div className="cm-modal">


### PR DESCRIPTION
as mentioned in #49 it would be great to have different links to privacyPolicy for different languages. 

so in order to be able to do so, this adds the option to set these links like this:

```
privacyPolicy: {
   default: '/#privacy',
   de: '/#datenschutz',
},
```
