### PR TITLE
Added "acceptSelected" to the German translation

### DIFF
--- a/src/translations/de.yml
+++ b/src/translations/de.yml
@@ -15,6 +15,7 @@ ok: OK
 save: Speichern
 decline: Ablehnen
 close: Schließen
+acceptSelected: Auswahl speichern
 acceptAll: Allen zustimmen
 app:
   disableAll:


### PR DESCRIPTION
`acceptSelected` is missing from the German translation

Closes #182 