### PR TITLE
Moved "Accept all" to the right

### DIFF
--- a/src/components/consent-modal.js
+++ b/src/components/consent-modal.js
@@ -29,7 +29,7 @@ export default class ConsentModal extends React.Component {
         let declineButton
 
         if (!config.hideDeclineAll && ! manager.confirmed)
-            declineButton = <button disabled={confirming} className="cm-btn cm-btn-decline cm-btn-right cm-btn-sm cm-btn-danger cn-decline" type="button" onClick={declineAndHide}>{t(['decline'])}</button>
+            declineButton = <button disabled={confirming} className="cm-btn cm-btn-decline cm-btn-sm cm-btn-danger cn-decline" type="button" onClick={declineAndHide}>{t(['decline'])}</button>
         let acceptAllButton
         const acceptButton =
             <button disabled={confirming} className="cm-btn cm-btn-success cm-btn-info cm-btn-accept" type="button" onClick={saveAndHide}>{t([manager.confirmed ? 'save' : 'acceptSelected'])}</button>
@@ -58,9 +58,9 @@ export default class ConsentModal extends React.Component {
                 </div>
                 <div className="cm-footer">
                     <div className="cm-footer-buttons">
-                        {acceptAllButton}
-                        {acceptButton}
                         {declineButton}
+                        {acceptButton}
+                        {acceptAllButton}
                     </div>
                     <p className="cm-powered-by"><a target="_blank" href={config.poweredBy || 'https://klaro.kiprotect.com'} rel="noopener noreferrer">{t(['poweredBy'])}</a></p>
                 </div>

--- a/src/components/consent-notice.js
+++ b/src/components/consent-notice.js
@@ -90,11 +90,13 @@ export default class ConsentNotice extends React.Component {
                     {t(['consentNotice', 'description'], {purposes: <strong>{purposesText}</strong>})}
                 </p>
                 {changesText}
-                <p className="cn-ok">
-                    {declineButton}
-                    {acceptButton}
+                <div className="cn-ok">
                     <a className="cm-link cm-learn-more" href="#" onClick={showModal}>{t(['consentNotice', 'learnMore'])}...</a>
-                </p>
+                    <div className="cn-buttons">
+                        {declineButton}
+                        {acceptButton}
+                    </div>
+                </div>
             </div>
         </div>
     }

--- a/src/scss/klaro.scss
+++ b/src/scss/klaro.scss
@@ -47,7 +47,7 @@ $green3: #01440C;
         }
 
         .cm-link {
-            padding-left: 4px;
+            margin-right: 0.5em;
             vertical-align: middle;
         }
 
@@ -152,15 +152,9 @@ $green3: #01440C;
                 border-top: $border-dark;
 
                 &-buttons {
-                    &::before,
-                    &::after {
-                        content: " ";
-                        display: table;
-                    }
-
-                    &::after {
-                        clear: both;
-                    }
+                    display: flex;
+                    flex-flow: row;
+                    justify-content: space-between;
                 }
 
                 .cm-powered-by {
@@ -260,6 +254,9 @@ $green3: #01440C;
             right: 20px;
             max-width: 300px;
         }
+        @media(min-width: 1400px){
+            max-width: 350px;
+        }
 
         @media(max-width: 989px){
             border: none;
@@ -287,9 +284,13 @@ $green3: #01440C;
 
             }
 
-            p.cn-ok {
-                padding-top: 0.5em;
-                margin: 0;
+            .cn-ok {
+                display: flex;
+                flex-flow: row;
+                justify-content: space-between;
+                align-items: center;
+
+                margin-top: 1em;
             }
         }
 


### PR DESCRIPTION
Moved the "accept all" button to the right as accept/submit button are the buttons on the right.

The change make sure most people will use the "accept all" button if enabled.

Closes: #183 