### PR TITLE
Add the missing config name as dataset to the klaro script tag

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -361,7 +361,7 @@
                 <div class="column is-6 column-eq">
                     <pre><code class="language-javascript">&lt;script defer type="application/javascript"
         src="config.js"&gt;&lt;/script&gt;
-&lt;script defer type="application/javascript"
+&lt;script defer data-config="consentConfig" type="application/javascript"
         src="klaro.js"&gt;&lt;/script&gt;</code></pre>
                 </div>
                 <div class="column is-6 column-eq">


### PR DESCRIPTION
Without this small change the provided documentation is incorrect and the user is not able to get klaro to work!