### PR TITLE
rename consentConfig to klaroConfig

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -292,7 +292,7 @@
             <h2 class="subtitle">Write the config file (no worries, it's easy)</h2>
             <div class="columns">
                 <div class="column is-6 column-eq">
-                    <pre><code class="language-javascript">window.consentConfig = {
+                    <pre><code class="language-javascript">window.klaroConfig = {
     privacyPolicy: '/privacy.html',
     apps : [
         {
@@ -386,7 +386,7 @@
                 <div class="column is-6 column-eq">
                     <pre><code class="language-javascript">&lt;script defer type="application/javascript"
         src="config.js"&gt;&lt;/script&gt;
-&lt;script defer data-config="consentConfig" type="application/javascript"
+&lt;script defer data-config="klaroConfig" type="application/javascript"
         src="klaro.js"&gt;&lt;/script&gt;</code></pre>
                 </div>
                 <div class="column is-6 column-eq">


### PR DESCRIPTION
It is quite confusing that the docs at https://klaro.kiprotect.com/ call the config variable `consentConfig`, but then the example config uses `klaroConfig` which is the default, which means that if someone copies the default config and the default JS from the website...
```html
<script defer type="application/javascript" src="config.js"></script>
<script defer data-config="consentConfig" type="application/javascript" src="klaro.js"></script>
```
... nothing works and Klaro doesn't even show a console warning or error.