### PR TITLE
Trigger re-execution for LINK tags as well

### DIFF
--- a/examples/klaro-and-webpack/dist/index.html
+++ b/examples/klaro-and-webpack/dist/index.html
@@ -9,6 +9,7 @@
     <meta charset="utf-8"/>
     <title>Klaro as a script</title>
     <script src="main.js"></script>
+    <link rel="stylesheet" type="text/plain" data-name="bootstrap" data-href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" data-type="text/css">
   </head>
   <body>
     <h1>Klaro Example</h1>

--- a/examples/klaro-and-webpack/src/index.js
+++ b/examples/klaro-and-webpack/src/index.js
@@ -15,6 +15,7 @@ const config = {
             },
             purposes: {
                 analytics: "Analytics",
+                styling: "Styling",
             }
         }
     },
@@ -22,6 +23,12 @@ const config = {
         {
             name: "googleAnalytics",
             purposes: ["analytics"],
+        },
+        {
+            name: "bootstrap",
+            title: "Bootstrap (external resource)",
+            description: "Example for embedding external stylesheets.",
+            purposes: ["styling"],
         },
     ],
 };

--- a/src/consent-manager.js
+++ b/src/consent-manager.js
@@ -211,16 +211,16 @@ export default class ConsentManager {
             //if no consent was given we disable this tracker
             //we remove and add it again to trigger a re-execution
 
-            if (element.tagName === 'SCRIPT'){
+            if (element.tagName === 'SCRIPT' || element.tagName === 'LINK'){
                 // this element is already active, we do not touch it...
                 if (element.type === type){
                     // eslint-disable-next-line no-console
-                    console.debug(`Skipping script for service ${service.name}, as it already has the correct type...`)
+                    console.debug(`Skipping ${element.tagName} for service ${service.name}, as it already has the correct type...`)
                     continue
                 }
                 // we create a new script instead of updating the node in
                 // place, as the script won't start correctly otherwise
-                const newElement = document.createElement('script')
+                const newElement = document.createElement(element.tagName)
                 for(const attribute of element.attributes){
                     newElement.setAttribute(attribute.name, attribute.value)
                 }
@@ -232,6 +232,8 @@ export default class ConsentManager {
                     newElement.type = type
                     if (ds.src !== undefined)
                         newElement.src = ds.src
+                    if (ds.href !== undefined)
+                        newElement.href = ds.href
                 } else {
                     newElement.type = 'text/plain'
                 }


### PR DESCRIPTION
Managing external `<link>` stylesheets via Klaro! also require re-execution similarly to `<script>` includes.

Sample usage:
```
<link rel="stylesheet" type="text/plain" media="all" data-type="text/css" data-href="https://assets.juicer.io/embed.css" data-name="socialmedia">
```