### PR TITLE
Fix typo in German translation

### DIFF
--- a/src/translations/de.yml
+++ b/src/translations/de.yml
@@ -41,7 +41,7 @@ purposes:
     title: Werbung
   functional:
     description: 'Diese Dienste sind für das korrekte Funktionieren dieser Website
-      unerlässlich. Sie können sie hier nicht deaktiviert werden, da der Dienst sonst
+      unerlässlich. Sie können sie hier nicht deaktivieren, da der Dienst sonst
       nicht richtig funktionieren würde.
 
       '

--- a/src/translations/de.yml
+++ b/src/translations/de.yml
@@ -40,7 +40,7 @@ purposes:
       oder interessenbezogene Werbung zu zeigen.
     title: Werbung
   functional:
-    description: 'Diese Dienste sind für das korrekte Funktionieren dieser Website
+    description: 'Diese Dienste sind für die korrekte Funktion dieser Website
       unerlässlich. Sie können sie hier nicht deaktivieren, da der Dienst sonst
       nicht richtig funktionieren würde.
 


### PR DESCRIPTION
I just spotted a typo in the Germany translation.