### PR TITLE
Fix a 404 error for contextual consent notices

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -141,7 +141,7 @@ export function renderContextualConsentNotices(manager, tt, lang, config, opts){
                     if (ds['original-display'] === undefined)
                         ds['original-display'] = element.style.display
                     applyDataset(ds, element)
-                    element.src = undefined
+                    element.src = ''
                     element.style.display = 'none'
                 }
             }


### PR DESCRIPTION
The browser console currently displays `GET …/undefined 404 (not found)` for contextual consent notices, since `undefined` will be casted to a string.