### PR TITLE
Allow the type to be changed for other tags

### DIFF
--- a/src/consent-manager.js
+++ b/src/consent-manager.js
@@ -247,7 +247,7 @@ export default class ConsentManager {
             const parent = element.parentElement
             const ds = dataset(element)
             const {type, src, href} = ds
-            const attrs = ['href', 'src']
+            const attrs = ['href', 'src', 'type']
 
             //if no consent was given we disable this tracker
             //we remove and add it again to trigger a re-execution


### PR DESCRIPTION
That way you could change the type attribute of a style tag from text/plain to text/css. The latest Chrome, Firefox and Opera toggle the styles fine with that on a Mac. The text/plain styles are initially not executed and they are reset after the service is disabled. Mobile browsers and IE/Edge have to be checked.

```
<style type="text/plain" data-type="text/css" data-name="styling">
    h1 {
        color: #f00;
    }
</style>
```

A client likes to enable/disable external fonts provided by fonts.com with a counting tracker and this could work inline without referring an external css file.

```
<style type="text/plain" data-type="text/css" data-name="styling">
@import url("http://fast.fonts.net/t/1.css?apiType=css&projectid=XXXXXXXXX");
    @font-face{
        font-family:"Brandon Text W04";
        src:url("Fonts/XXXXXXX.woff2") format("woff2"),url("Fonts/XXXXXXXX.woff") format("woff");
font-weight: 330;
font-style: normal;
    }
</style>
```