### PR TITLE
Fix syntax error in modal.scss

### DIFF
--- a/src/scss/modal.scss
+++ b/src/scss/modal.scss
@@ -1,7 +1,7 @@
 @mixin modal($centerWidth, $windowWidth) {
 
-    @include var(background-color, dark1)
-        @include var(color, light1);
+    @include var(background-color, dark1);
+    @include var(color, light1);
 
     z-index: 1001;
     box-shadow: $cm-box-shadow-dark-md;


### PR DESCRIPTION
The SCSS doesn't compile anymore since v0.7.12, because of this syntax error in modal.scss.