### PR TITLE
Add a config parameter for the cookie path of the consent cookie

### DIFF
--- a/dist/config.js
+++ b/dist/config.js
@@ -55,7 +55,7 @@ var klaroConfig = {
     //cookieDomain: '.github.com',
 
     // You can change to cookie path for the consent manager itself.
-    // Use this to restrict the cookie visibilita to a specific path.
+    // Use this to restrict the cookie visibility to a specific path.
     // If undefined, Klaro will use '/' as cookie path.
     //cookiePath: '/',
 

--- a/dist/config.js
+++ b/dist/config.js
@@ -54,6 +54,11 @@ var klaroConfig = {
     // If undefined, Klaro will use the current domain.
     //cookieDomain: '.github.com',
 
+    // You can change to cookie path for the consent manager itself.
+    // Use this to restrict the cookie visibilita to a specific path.
+    // If undefined, Klaro will use '/' as cookie path.
+    //cookiePath: '/',
+
     // Defines the default state for services (true=enabled by default).
     default: false,
 

--- a/src/components/ide/spec.js
+++ b/src/components/ide/spec.js
@@ -113,6 +113,13 @@ const KlaroConfigSpec = {
             default: '',
         },
         {
+            name: 'cookiePath',
+            applicable: (config) => config.storageMethod === 'cookie',
+            control: 'RetractingLabelInput',
+            validators: [],
+            default: '',
+        },
+        {
             name: 'htmlTexts',
             control: 'Switch',
             validators: [],

--- a/src/consent-manager.js
+++ b/src/consent-manager.js
@@ -45,6 +45,10 @@ export default class ConsentManager {
         return this.config.cookieDomain || undefined
     }
 
+    get cookiePath(){
+        return this.config.cookiePath || undefined
+    }
+
     get cookieExpiresAfterDays(){
         return this.config.cookieExpiresAfterDays || 120
     }

--- a/src/stores.js
+++ b/src/stores.js
@@ -23,6 +23,7 @@ export class CookieStore {
     constructor(manager) {
         this.cookieName = manager.storageName
         this.cookieDomain = manager.cookieDomain
+        this.cookiePath = manager.cookiePath
         this.cookieExpiresAfterDays = manager.cookieExpiresAfterDays
     }
 
@@ -34,7 +35,7 @@ export class CookieStore {
     }
 
     set(value) {
-        return setCookie(this.cookieName, value, this.cookieExpiresAfterDays, this.cookieDomain)
+        return setCookie(this.cookieName, value, this.cookieExpiresAfterDays, this.cookieDomain, this.cookiePath)
     }
 
     delete() {

--- a/src/utils/cookies.js
+++ b/src/utils/cookies.js
@@ -23,7 +23,7 @@ export function getCookie(name) {
 }
 
 //https://stackoverflow.com/questions/14573223/set-cookie-and-get-cookie-with-javascript
-export function setCookie(name, value, days, domain) {
+export function setCookie(name, value, days, domain, path) {
     let expires = '';
     if (days) {
         const date = new Date();
@@ -33,8 +33,13 @@ export function setCookie(name, value, days, domain) {
     if (domain !== undefined) {
         expires += '; domain=' + domain;
     }
+    if (path !== undefined) {
+        expires += '; path=' + path;
+    } else {
+        expires += '; path=/';
+    }
     document.cookie =
-        name + '=' + (value || '') + expires + '; path=/; SameSite=Lax';
+        name + '=' + (value || '') + expires + '; SameSite=Lax';
 }
 
 export function deleteCookie(name, path, domain) {


### PR DESCRIPTION
This PR adds a cookiePath parameter to the config to set the cookie path of the consent cookie.

This would fix #63 since the cookieDomain is already configurable