### PR TITLE
now sets klaro-modal-open to body klaro-modal is open

### DIFF
--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -27,9 +27,10 @@ export default class App extends React.Component {
         if (api !== undefined) {
             if (modal || show > 0) return;
             if (!this.props.manager.confirmed) {
-                const shownBefore = this.props.manager.auxiliaryStore.getWithKey(
-                    'shown-before'
-                );
+                const shownBefore =
+                    this.props.manager.auxiliaryStore.getWithKey(
+                        'shown-before'
+                    );
                 if (!shownBefore) {
                     api.update(this, 'showNotice', { config: config });
                     this.props.manager.auxiliaryStore.setWithKey(
@@ -60,7 +61,10 @@ export default class App extends React.Component {
         const { additionalClass, embedded, stylePrefix } = config;
 
         const hide = () => {
-            if (!embedded) this.setState({ show: false });
+            if (!embedded) {
+                document.body.classList.remove('klaro-modal-open');
+                this.setState({ show: false });
+            }
         };
         return (
             <div

--- a/src/components/consent-modal.jsx
+++ b/src/components/consent-modal.jsx
@@ -5,7 +5,6 @@ import Purposes from './purposes';
 import Text from './text';
 
 export default class ConsentModal extends React.Component {
-
     render() {
         const {
             hide,
@@ -84,9 +83,8 @@ export default class ConsentModal extends React.Component {
             }
         } else {
             // this is the modern way
-            ppUrl = t(['!', 'privacyPolicyUrl'], {lang: lang})
-            if (ppUrl !== undefined)
-                ppUrl = ppUrl.join('')
+            ppUrl = t(['!', 'privacyPolicyUrl'], { lang: lang });
+            if (ppUrl !== undefined) ppUrl = ppUrl.join('');
         }
 
         let ppLink;
@@ -103,7 +101,10 @@ export default class ConsentModal extends React.Component {
             servicesOrPurposes = (
                 <Purposes t={t} config={config} manager={manager} lang={lang} />
             );
-        else servicesOrPurposes = <Services t={t} config={config} manager={manager} lang={lang} />;
+        else
+            servicesOrPurposes = (
+                <Services t={t} config={config} manager={manager} lang={lang} />
+            );
 
         const innerModal = (
             <div className="cm-modal cm-klaro">
@@ -121,13 +122,9 @@ export default class ConsentModal extends React.Component {
                             text={[t(['consentModal', 'description'])].concat(
                                 (ppLink &&
                                     [' '].concat(
-                                        t(
-                                            [
-                                                'privacyPolicy',
-                                                'text',
-                                            ],
-                                            { privacyPolicy: ppLink }
-                                        )
+                                        t(['privacyPolicy', 'text'], {
+                                            privacyPolicy: ppLink,
+                                        })
                                     )) ||
                                     []
                             )}
@@ -141,8 +138,7 @@ export default class ConsentModal extends React.Component {
                         {acceptButton}
                         {acceptAllButton}
                     </div>
-                    {
-                        !config.disablePoweredBy &&
+                    {!config.disablePoweredBy && (
                         <p className="cm-powered-by">
                             <a
                                 target="_blank"
@@ -155,13 +151,15 @@ export default class ConsentModal extends React.Component {
                                 {t(['poweredBy'])}
                             </a>
                         </p>
-                    }
+                    )}
                 </div>
             </div>
         );
 
         if (embedded)
             return <div className="cookie-modal cm-embedded">{innerModal}</div>;
+
+        document.body.classList.add('klaro-modal-open');
 
         return (
             <div className="cookie-modal">

--- a/src/components/consent-notice.jsx
+++ b/src/components/consent-notice.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ConsentModal from './consent-modal';
 import { getPurposes } from '../utils/config';
 import Text from './text';
-import { asTitle } from '../utils/strings' 
+import { asTitle } from '../utils/strings';
 
 export default class ConsentNotice extends React.Component {
     constructor(props) {
@@ -35,16 +35,14 @@ export default class ConsentNotice extends React.Component {
             !confirmed &&
             (modal || this.props.config.mustConsent)
         ) {
-
             const close = () => {
-                this.setState({confirming: false});
+                this.setState({ confirming: false });
                 this.props.hide();
             };
 
-            this.setState({confirming: true})
-            if (changedServices === 0)
-                close()
-            else{
+            this.setState({ confirming: true });
+            if (changedServices === 0) close();
+            else {
                 setTimeout(close, 800);
             }
         } else {
@@ -71,17 +69,24 @@ export default class ConsentNotice extends React.Component {
 
         // we exclude functional services from this list, as they are always required and
         // the user cannot decline their use...
-        const purposeOrder = config.purposeOrder || []
-        const purposes = getPurposes(config).filter(purpose => purpose !== 'functional').sort((a,b) => purposeOrder.indexOf(a)-purposeOrder.indexOf(b));
-        const purposesTranslations = purposes
-            .map((purpose) => t(['!', 'purposes', purpose, 'title?']) || asTitle(purpose))
-        let purposesText = ''
+        const purposeOrder = config.purposeOrder || [];
+        const purposes = getPurposes(config)
+            .filter((purpose) => purpose !== 'functional')
+            .sort((a, b) => purposeOrder.indexOf(a) - purposeOrder.indexOf(b));
+        const purposesTranslations = purposes.map(
+            (purpose) =>
+                t(['!', 'purposes', purpose, 'title?']) || asTitle(purpose)
+        );
+        let purposesText = '';
         if (purposesTranslations.length === 1)
-            purposesText = purposesTranslations[0]
+            purposesText = purposesTranslations[0];
         else
-            purposesText = [...purposesTranslations.slice(0, -2), purposesTranslations.slice(-2).join(' & ')].join(', ');
+            purposesText = [
+                ...purposesTranslations.slice(0, -2),
+                purposesTranslations.slice(-2).join(' & '),
+            ].join(', ');
         let ppUrl;
-        // to do: deprecate and remove this 
+        // to do: deprecate and remove this
         if (config.privacyPolicy !== undefined) {
             if (typeof config.privacyPolicy === 'string')
                 ppUrl = config.privacyPolicy;
@@ -91,11 +96,9 @@ export default class ConsentNotice extends React.Component {
             }
         } else {
             // this is the modern way
-            ppUrl = t(['!', 'privacyPolicyUrl'], {lang: lang})
-            if (ppUrl !== undefined)
-                ppUrl = ppUrl.join('')
+            ppUrl = t(['!', 'privacyPolicyUrl'], { lang: lang });
+            if (ppUrl !== undefined) ppUrl = ppUrl.join('');
         }
-
 
         const showModal = (e) => {
             e.preventDefault();
@@ -104,6 +107,7 @@ export default class ConsentNotice extends React.Component {
 
         const hideModal = () => {
             if (config.mustConsent && !config.acceptAll) return;
+            document.body.classList.remove('klaro-modal-open');
             if (manager.confirmed && !testing) this.props.hide();
             else this.setState({ modal: false });
         };
@@ -208,7 +212,7 @@ export default class ConsentNotice extends React.Component {
         const notice = (
             <div
                 className={`cookie-notice ${
-                    (!noticeIsVisible && !testing) ? 'cookie-notice-hidden' : ''
+                    !noticeIsVisible && !testing ? 'cookie-notice-hidden' : ''
                 } ${noticeAsModal ? 'cookie-modal-notice' : ''} ${
                     embedded ? 'cn-embedded' : ''
                 }`}
@@ -218,7 +222,9 @@ export default class ConsentNotice extends React.Component {
                         <Text
                             config={config}
                             text={t(['consentNotice', 'description'], {
-                                purposes: <strong key="strong">{purposesText}</strong>,
+                                purposes: (
+                                    <strong key="strong">{purposesText}</strong>
+                                ),
                                 privacyPolicy: ppLink,
                                 learnMoreLink: learnMoreLink(),
                             })}
@@ -238,7 +244,6 @@ export default class ConsentNotice extends React.Component {
         );
 
         if (!noticeAsModal) return notice;
-
 
         return (
             <div className="cookie-modal">


### PR DESCRIPTION
This enables the user to prevent scrolling in background of the klaro modal.
CSS:

`
body.modal-open {
    overflow: hidden;
    padding-right: var(--scrollbar-width);
}
`