### PR TITLE
Add id some elements to allow propper functioning of 'i-dont-care-abo…

### DIFF
--- a/src/components/consent-modal.jsx
+++ b/src/components/consent-modal.jsx
@@ -149,7 +149,7 @@ export default class ConsentModal extends React.Component {
                                 href={
                                     config.poweredBy ||
                                     'https://kiprotect.com/klaro'
-                                }
+                                }   
                                 rel="noopener"
                             >
                                 {t(['poweredBy'])}
@@ -161,10 +161,10 @@ export default class ConsentModal extends React.Component {
         );
 
         if (embedded)
-            return <div className="cookie-modal cm-embedded">{innerModal}</div>;
+            return <div id="cookieScreen" className="cookie-modal cm-embedded">{innerModal}</div>;
 
         return (
-            <div className="cookie-modal">
+            <div id="cookieScreen" className="cookie-modal">
                 <div className="cm-bg" onClick={hide} />
                 {innerModal}
             </div>

--- a/src/components/consent-notice.jsx
+++ b/src/components/consent-notice.jsx
@@ -241,7 +241,7 @@ export default class ConsentNotice extends React.Component {
 
 
         return (
-            <div className="cookie-modal">
+            <div id="cookieScreen" className="cookie-modal">
                 <div className="cm-bg" />
                 {notice}
             </div>

--- a/src/components/ide/ide.jsx
+++ b/src/components/ide/ide.jsx
@@ -44,7 +44,7 @@ export class IDEModal extends React.Component {
 
         return (
             <div className={stylePrefix || 'klaro'}>
-                <div className="cookie-modal">
+                <div id="cookieScreen" className="cookie-modal">
                     <div className="cm-bg" onClick={hide} />
                     <div className="cm-modal cm-ide">
                         <div className="cm-header">


### PR DESCRIPTION
We have noticed that some customers complained that our website enyway.com is not usable for them. It turned out that these users use a popular plugin called 'i-dont-care-about-cookies' which 'clicks away' cookie banners.

Apparently this plugin applies a custom style to every page setting certain html elementes to `display: none`. In the case of the Klaro consent manager this only matches the modal dialogue but not the dark translucent modal background. This makes a website that uses the modal klaro consent management unusable for users with the 'i-dont-care-about-cookies' plugin. https://www.i-dont-care-about-cookies.eu

- Add 'cookie-modal' id to consent-modal and consent-notice component to allow the plugin to set them to 'display: none'