### PR TITLE
Fix compliance cookie not deleting if domain specified as .example.com

### DIFF
--- a/src/stores.js
+++ b/src/stores.js
@@ -39,7 +39,7 @@ export class CookieStore {
     }
 
     delete() {
-        return deleteCookie(this.cookieName);
+        return deleteCookie(this.cookieName, this.cookiePath, this.cookieDomain);
     }
 }
 


### PR DESCRIPTION
On deploying to our staging environment the compliance cookie was refusing to delete on clicking the reset consent button e.g:

```
klaro.getManager(klaroConfig).resetConsents(); klaro.show(klaroConfig);
```

The initial consent manager showed until the page was refreshed and the previous consent restored from the not-yet-deleted-cookie, resulting in non-compliance.

It was working fine on `localhost` but not `staging.ourdomain.com` with the "cookieDomain" set to ".staging.ourdomain.com".

I hope this is a relevant / good change, if good and you need the /dist/ contents regenerated and committed/pushed please let me know.
