### PR TITLE
add customizability for contextual consent notice description

### DIFF
--- a/dist/config.js
+++ b/dist/config.js
@@ -123,6 +123,11 @@ var klaroConfig = {
             externalTracker: {
                 description: 'Beispiel für ein externes Tracking Skript',
             },
+            recaptcha: {
+                contextualDescriptions: {
+                    default: 'Möchten Sie Recaptcha laden, um das Kontaktformular anzuzeigen?',
+                }
+            },
             adsense: {
                 description: 'Anzeigen von Werbeanzeigen (Beispiel)',
                 title: 'Google AdSense Werbezeugs',
@@ -166,6 +171,11 @@ var klaroConfig = {
             },
             externalTracker: {
                 description: 'Example of an external tracking script',
+            },
+            recaptcha: {
+                contextualDescriptions: {
+                    default: 'Do you want to load Recaptcha to view the contact form?',
+                }
             },
             adsense: {
                 description: 'Displaying of advertisements (just an example)',
@@ -302,6 +312,11 @@ var klaroConfig = {
             title: 'Intercom',
             default: true,
             purposes: ['livechat'],
+        },
+        {
+            name: 'recaptcha',
+            title: 'Recaptcha',
+            purposes: ['security'],
         },
         {
             name: 'mouseflow',

--- a/src/components/contextual-consent-notice.jsx
+++ b/src/components/contextual-consent-notice.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { asTitle } from '../utils/strings';
 import { t as tt } from '../utils/i18n';
 
-const ContextualConsentNotice = ({manager, style, config, t, lang, service}) => {
+const ContextualConsentNotice = ({manager, style, config, t, lang, service, id}) => {
 
     const [updateCnt, setUpdateCnt] = useState(0)
 
@@ -35,6 +35,7 @@ const ContextualConsentNotice = ({manager, style, config, t, lang, service}) => 
     })
 
     const title = tt(service.translations || {}, lang, 'zz', ['!', 'title']) || t(['!', service.name, 'title?']) || asTitle(service.name)
+    const description = tt(config.translations || {}, lang, 'zz', ['!', service.name, 'contextualDescriptions', id]) || tt(config.translations || {}, lang, 'zz', ['!', service.name, 'contextualDescriptions', 'default']) || t(['contextualConsent','description'], {title: title})
 
     return <div
                 lang={lang}
@@ -45,7 +46,7 @@ const ContextualConsentNotice = ({manager, style, config, t, lang, service}) => 
             >
             <div className={"context-notice"+(style !== undefined ? ` cm-${style}` : "")}>
             <p>
-                {t(['contextualConsent','description'], {title: title})}
+                {description}
             </p>
             <p className="cm-buttons">
                 <button

--- a/src/lib.js
+++ b/src/lib.js
@@ -114,6 +114,7 @@ export function renderContextualConsentNotices(manager, tt, lang, config, opts){
         const consent = manager.getConsent(service.name) && manager.confirmed
         const elements = document.querySelectorAll("[data-name='"+service.name+"']")
         for(const element of elements){
+            const dataId = element.getAttribute("data-id")
             const ds = dataset(element)
             if (ds.type === 'placeholder')
                 continue
@@ -139,6 +140,7 @@ export function renderContextualConsentNotices(manager, tt, lang, config, opts){
                         manager={manager}
                         config={config}
                         service={service}
+                        id={dataId}
                         style={ds.style}
                         testing={opts.testing}
                         api={opts.api} />, placeholderElement)


### PR DESCRIPTION
On a lot of websites, I need the ability to customize the contextual consent descriptions.

Imagine using Recaptcha for spam protection of a contact form. When the user disabled cookies and the contextual consent is displayed, its description would read “Do you want to load external content supplied by Recaptcha?”.

Wouldn't it be better if it would say “Do you want to load Recaptcha to view the contact form?”. Then the user would know WHY Recaptcha needs to be loaded.

And since you could need Recaptcha for multiple purposes and at multiple places, I used the `data-id` attribute to address allow multiple custom descriptions per service.

The global translated contextual consent description is untouched and if the new `contextualDescriptions` option or the `data-id` attribute is not set, nothing changes.

Example:

```html
<div data-name="recaptcha" data-id="contact-form"></div>
```

```js
googleMaps: {
     contextualDescriptions: {
          default: 'We use Recaptcha for Spam-Protection. Do you want to load it?',
          "contact-form": 'Do you want to load Recaptcha to view the contact form?',
     }
},
```
