### PR TITLE
Fixed an issue with Klaro autofocus

### DIFF
--- a/src/components/consent-notice.jsx
+++ b/src/components/consent-notice.jsx
@@ -13,6 +13,12 @@ export default class ConsentNotice extends React.Component {
         };
     }
 
+    componentDidMount() {
+        if (this.props.config.autoFocus && this.noticeRef) {
+            this.noticeRef.focus()
+        }
+    }
+
     componentDidUpdate(prevProps) {
         if (prevProps.modal !== this.props.modal)
             this.setState({ modal: this.props.modal });


### PR DESCRIPTION
Klaro loses its autofocus when the main page, into which Klaro has been loaded, focuses on one of its own elements. Accepting or rejecting cookie consent should be first thing on focus (if the  `autofocus` is set to `true` in config). This is an accessibility issue for keyboard navigation.

To test this issue in action:

- Set `autofocus` to `true` in config.js located in `klaro-js/dist/config.js`
- In the `simple.html` located in `klaro-js/dist/examples/simple.html`, add an input element in the body with an id, for example `<input id="autofocus-test"></input>`, then create a new script tag like so `<script>document.getElementById("autofocus-test").focus()</script>`
- Opening the example page `simple.html` will result the focus going to the input box instead of klaro's cookie notice.
