### PR TITLE
Fix use of declarations after nested rules (deprecated since Sass 1.77.7)

### DIFF
--- a/src/scss/klaro.scss
+++ b/src/scss/klaro.scss
@@ -428,10 +428,9 @@
     }
 
     .cookie-modal-notice {
-        @include modal(400px, 400px);
-
         padding: 1em;
         padding-top: 0.2em;
+        @include modal(400px, 400px);
 
         .cn-ok {
             display: flex;


### PR DESCRIPTION
When using sass@1.77.7, some warnings occur when running `npm run css`. More info at Sass: [Breaking Change: Mixed Declarations](https://sass-lang.com/documentation/breaking-changes/mixed-decls/).

The fix is to move the calls to mixins in the code and the warnings are not displayed anymore.