### PR TITLE
fix: YAMLParseError hu.yml

### DIFF
--- a/src/translations/hu.yml
+++ b/src/translations/hu.yml
@@ -51,5 +51,5 @@ contextualConsent:
   description: Szeretné betölteni azt a külső tartalmat, amelyet {title} szolgáltat?
   acceptOnce: Igen
   acceptAlways: Mindig
-  descriptionEmptyStore: Amennyiben beleegyezik ebbe a szolgáltatásba, el kell fogadnia a következőket: {title} itt: {link}.
+  descriptionEmptyStore: 'Amennyiben beleegyezik ebbe a szolgáltatásba, el kell fogadnia a következőket: {title} itt: {link}.'
   modalLinkText: Jóváhagyás kezelő


### PR DESCRIPTION
Build fails like
```
ERROR in ./translations/hu.yml
Module build failed (from ../node_modules/yaml-loader/index.js):
YAMLParseError: Nested mappings are not allowed in compact mappings at line 54, column 26:

  descriptionEmptyStore: Amennyiben beleegyezik ebbe a szolgáltatásba, el kell …
```