### PR TITLE
targeting browsers 2025

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
   "author": "KIProtect GmbH",
   "browserslist": [
-    "> 0.25%",
-    "IE 11",
-    "IE 9"
+    "defaults"
   ],
   "bugs": {
     "url": "https://github.com/KIProtect/klaro/issues"


### PR DESCRIPTION
IE9/11 are both old (2011/13) and longe gone (2016/22). Defaults in fact is:
```
[
    "> 0.5%",
    "last 2 versions", 
    "not dead"
]
```
After `npx update-browserslist-db@latest` bundele size is significantly smaller.